### PR TITLE
Prevent synthesizing guard statements for default values

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "165fc6d22394c1168ff76ab5d951245971ef07e5",
-        "version" : "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-06-05-a"
+        "revision" : "fa8f95c2d536d6620cc2f504ebe8a6167c9fc2dd",
+        "version" : "510.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        // Depend on the latest Swift 5.9 prerelease of SwiftSyntax
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0-swift-5.9-DEVELOPMENT-SNAPSHOT-2023-04-25-b"),
+        .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Sources/BuilderMacroMacros/Extensions/DeclGroupSyntax+Extensions.swift
+++ b/Sources/BuilderMacroMacros/Extensions/DeclGroupSyntax+Extensions.swift
@@ -20,6 +20,12 @@ extension DeclGroupSyntax {
             .filter(\.isStoredProperty)
     }
 
+    var initializer: InitializerDeclSyntax? {
+        memberBlock.members.first(
+            where: { $0.decl.is(InitializerDeclSyntax.self) }
+        )?.decl.as(InitializerDeclSyntax.self)
+    }
+
     var isStruct: Bool {
         self.as(StructDeclSyntax.self) != nil
     }

--- a/Sources/BuilderMacroMacros/Extensions/DeclGroupSyntax+Extensions.swift
+++ b/Sources/BuilderMacroMacros/Extensions/DeclGroupSyntax+Extensions.swift
@@ -11,7 +11,7 @@ extension DeclGroupSyntax {
     /// Declaration name
     /// example: struct User will return "User"
     var name: String? {
-        asProtocol(IdentifiedDeclSyntax.self)?.identifier.text
+        asProtocol(NamedDeclSyntax.self)?.name.text
     }
 
     var storedVariables: [VariableDeclSyntax] {

--- a/Sources/BuilderMacroMacros/Extensions/VariableDeclSyntax+Extensions.swift
+++ b/Sources/BuilderMacroMacros/Extensions/VariableDeclSyntax+Extensions.swift
@@ -29,7 +29,7 @@ extension VariableDeclSyntax {
     }
 
     private var typeSyntax: TypeSyntax? {
-        bindings.first?.typeAnnotation?.as(TypeAnnotationSyntax.self)?.type
+        bindings.first?.typeAnnotation?.type
     }
 
 }
@@ -46,13 +46,13 @@ extension VariableDeclSyntax {
         }
 
         let binding = bindings.first!
-        switch binding.accessor {
+        switch binding.accessorBlock?.accessors {
         case .none:
             return true
 
         case .accessors(let node):
-            for accessor in node.accessors {
-                switch accessor.accessorKind.tokenKind {
+            for accessor in node {
+                switch accessor.accessorSpecifier.tokenKind {
                 case .keyword(.willSet), .keyword(.didSet):
                     // Observers can occur on a stored property.
                     break

--- a/Tests/BuilderMacroTests/BuilderMacroTests.swift
+++ b/Tests/BuilderMacroTests/BuilderMacroTests.swift
@@ -13,9 +13,9 @@ final class BuilderMacroTests: XCTestCase {
         assertMacroExpansion("""
             @Builder
             struct User {
-            let uuid: UUID
-            let name: String
-            let age: Int?
+                let uuid: UUID
+                let name: String
+                let age: Int?
             }
             """,
             expandedSource: """
@@ -24,6 +24,7 @@ final class BuilderMacroTests: XCTestCase {
                 let uuid: UUID
                 let name: String
                 let age: Int?
+
                 public class Builder {
                     public var uuid: UUID?
                     public var name: String?
@@ -67,9 +68,9 @@ final class BuilderMacroTests: XCTestCase {
         assertMacroExpansion("""
             @ThrowingBuilder
             struct User {
-            let uuid: UUID
-            let name: String
-            let age: Int?
+                let uuid: UUID
+                let name: String
+                let age: Int?
             }
             """,
             expandedSource: """
@@ -78,6 +79,7 @@ final class BuilderMacroTests: XCTestCase {
                 let uuid: UUID
                 let name: String
                 let age: Int?
+
                 public class Builder {
                     private enum Error: Swift.Error {
                         case missingValue(property: String)


### PR DESCRIPTION
e.g.
```
            struct User {
                let uuid: UUID
                let name: String
                let age: Int?

                init(uuid: UUID, name: String = "Foo", age: Int? = nil) {
                    self.uuid = uuid
                    self.name = name
                    self.age = age
                }
            }
```
The `name` property should not be guard-checked. Updated test coverage.