### PR TITLE
@FluentBuilder annotation

### DIFF
--- a/Sources/BuilderMacro/BuilderMacro.swift
+++ b/Sources/BuilderMacro/BuilderMacro.swift
@@ -11,3 +11,10 @@ public macro ThrowingBuilder() = #externalMacro(
     module: "BuilderMacroMacros",
     type: "ThrowingBuilderMacro"
 )
+
+/// A macro that produces FluentBuilder
+@attached(member, names: arbitrary)
+public macro FluentBuilder() = #externalMacro(
+    module: "BuilderMacroMacros",
+    type: "FluentBuilderMacro"
+)

--- a/Sources/BuilderMacroClient/main.swift
+++ b/Sources/BuilderMacroClient/main.swift
@@ -17,6 +17,20 @@ struct Player {
     let hp: Int
 }
 
+@FluentBuilder
+struct Quote {
+    let uuid: UUID
+    let text: String
+    let author: String
+}
+
+let quote = Quote.makeBuilder()
+    .text("What a time to be alive")
+    .author("A dude")
+    .build()
+
+print(String(describing: quote))
+
 let throwingBuilder = Player.makeBuilder()
 
 do {

--- a/Sources/BuilderMacroMacros/BuilderBodyGenerator/BuilderBodyGenerator.swift
+++ b/Sources/BuilderMacroMacros/BuilderBodyGenerator/BuilderBodyGenerator.swift
@@ -11,8 +11,8 @@ import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
 extension BuilderBodyGenerator.Configuration {
-    static let throwing = Self(isThrowing: true)
-    static let fluent = Self(isFluent: true)
+    static let throwing = Self(flavour: .throwing)
+    static let fluent = Self(flavour: .fluent)
 }
 
 struct BuilderBodyGenerator {
@@ -26,12 +26,16 @@ struct BuilderBodyGenerator {
     }
     
     struct Configuration {
-        let isThrowing: Bool
-        let isFluent: Bool
-        
-        init(isThrowing: Bool = false, isFluent: Bool = false) {
-            self.isThrowing = isThrowing
-            self.isFluent = isFluent
+        enum Flavour {
+            case plain
+            case throwing
+            case fluent
+        }
+
+        let flavour: Flavour
+
+        init(flavour: Flavour = .plain) {
+            self.flavour = flavour
         }
     }
     
@@ -45,19 +49,20 @@ struct BuilderBodyGenerator {
         guard let memberName = declaration.name else {
             throw Error.missingDeclarationName
         }
-        
-        if configuration.isThrowing {
-            return generateThrowingBody(
+
+        return switch configuration.flavour {
+        case .plain:
+            generateBody(
                 memberName: memberName,
                 vars: declaration.typedMembers
             )
-        } else if configuration.isFluent {
-            return generateFluentBody(
+        case .throwing:
+            generateThrowingBody(
                 memberName: memberName,
                 vars: declaration.typedMembers
             )
-        } else {
-            return generateBody(
+        case .fluent:
+            generateFluentBody(
                 memberName: memberName,
                 vars: declaration.typedMembers
             )

--- a/Sources/BuilderMacroMacros/FluentBuilderMacroMacro.swift
+++ b/Sources/BuilderMacroMacros/FluentBuilderMacroMacro.swift
@@ -3,7 +3,7 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
-public struct BuilderMacro: MemberMacro {
+public struct FluentBuilderMacro: MemberMacro {
     enum Error: Swift.Error {
         case wrongDeclarationSyntax
     }
@@ -24,26 +24,7 @@ public struct BuilderMacro: MemberMacro {
             return []
         }
 
-        let bodyGenerator = BuilderBodyGenerator()
+        let bodyGenerator = BuilderBodyGenerator(configuration: .fluent)
         return try bodyGenerator.generateBody(from: declaration)
-    }
-}
-
-
-@main
-struct BuilderMacroPlugin: CompilerPlugin {
-    let providingMacros: [Macro.Type] = [
-        BuilderMacro.self,
-        ThrowingBuilderMacro.self,
-        FluentBuilderMacro.self
-    ]
-}
-
-extension BuilderMacro.Error: CustomStringConvertible {
-    var description: String {
-        switch self {
-        case .wrongDeclarationSyntax:
-            return "Builder Macro supports only structs"
-        }
     }
 }


### PR DESCRIPTION
Annotation is meant as an extension of the base @ Builder, in that it creates functions with the same name as the variable for simple variable types. Meant to better represent something like @ Builder (https://projectlombok.org/features/Builder), widely used in Java.